### PR TITLE
Add status checks integration for GitHub Actions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -132,3 +132,5 @@ Layout/LineLength:
 
 Metrics/BlockLength:
   Max: 35
+  Exclude:
+    - 'spec/**/*'

--- a/gitbar_app/models/pull_request.rb
+++ b/gitbar_app/models/pull_request.rb
@@ -1,4 +1,5 @@
 require_relative 'review'
+require_relative '../services/status_checks'
 
 # PullRequest
 # Value object for a GitHub pull request with reviews and review requests,
@@ -45,12 +46,49 @@ class PullRequest
     @title = pr_data.dig('title').gsub('|', ' ')
     @number = pr_data.dig('number')
     @url = pr_data.dig('url')
-    @status_check_rollup = pr_data.dig('statusCheckRollup', 0, 'targetUrl')
-    @status_check_rollup_state = pr_data.dig('statusCheckRollup', 0, 'state')
-    @status_check_rollup_context = pr_data.dig('statusCheckRollup', 0, 'context')
+    set_status_check_rollup(rollup_data: pr_data.dig('statusCheckRollup'))
     @author = pr_data.dig('author', 'login')
     @updated_at = pr_data.dig('updatedAt')
     @mergeable = pr_data.dig('mergeable')
     @head_ref_name = pr_data.dig('headRefName')
+  end
+
+  # statusCheckRollup is a list mixing StatusContext (legacy commit statuses)
+  # and CheckRun (GitHub Actions) entries. We aggregate them into one state and
+  # surface a representative check (a failing/pending one first) for the link.
+  def set_status_check_rollup(rollup_data:)
+    checks = (rollup_data || []).map { |check| normalize_rollup_check(check) }
+    return if checks.empty?
+
+    representative = representative_check(checks)
+    @status_check_rollup_state = StatusChecks.aggregate(checks.map { |check| check[:state] })&.upcase
+    @status_check_rollup_context = representative[:context]
+    @status_check_rollup = representative[:url]
+  end
+
+  # Surface the most actionable check for the displayed link/label:
+  # a failing one first, then a pending one, else the first.
+  def representative_check(checks)
+    checks.find { |check| check[:state] == 'failure' } ||
+      checks.find { |check| check[:state] == 'pending' } ||
+      checks.first
+  end
+
+  def normalize_rollup_check(check)
+    return check_run_rollup(check) if check['__typename'] == 'CheckRun' || check.key?('conclusion')
+
+    {
+      state: StatusChecks.commit_status_state(check['state']),
+      context: check['context'],
+      url: check['targetUrl']
+    }
+  end
+
+  def check_run_rollup(check)
+    {
+      state: StatusChecks.check_run_state(status: check['status'], conclusion: check['conclusion']),
+      context: check['name'] || check['workflowName'],
+      url: check['detailsUrl']
+    }
   end
 end

--- a/gitbar_app/models/repository.rb
+++ b/gitbar_app/models/repository.rb
@@ -1,6 +1,7 @@
 require_relative 'pull_request'
 require_relative 'review_request'
 require_relative '../services/gh_service'
+require_relative '../services/status_checks'
 
 # Repository
 # Value object for a GitHub repository with pull requests,
@@ -50,10 +51,22 @@ class Repository
   end
 
   def current_status
-    status = GhService.new(repo_name: @name).fetch_status(branch: @default_branch)
+    service = GhService.new(repo_name: @name)
+    combined = service.fetch_status(branch: @default_branch)
+    check_runs = service.fetch_check_runs(branch: @default_branch)
 
-    @status = status['state']
-    @status_details = status['statuses']
+    commit_statuses = combined['statuses'] || []
+    check_details = StatusChecks.normalize_check_runs(check_runs['check_runs'] || [])
+
+    # Merge legacy commit statuses and Actions check runs into one detail list.
+    @status_details = commit_statuses + check_details
+    @status = aggregate_status(combined_state: combined['state'], details: @status_details)
+  end
+
+  def aggregate_status(combined_state:, details:)
+    states = details.map { |detail| StatusChecks.commit_status_state(detail['state']) }
+    # No checks from either system: keep the API's combined state (legacy behavior).
+    StatusChecks.aggregate(states) || combined_state
   end
 
   def simple_name

--- a/gitbar_app/services/gh_service.rb
+++ b/gitbar_app/services/gh_service.rb
@@ -21,6 +21,16 @@ class GhService
     JSON.parse(status)
   end
 
+  # Check Runs (GitHub Actions). The combined commit status endpoint above is
+  # blind to Actions, so we fetch them separately and merge the two systems.
+  def fetch_check_runs(branch:)
+    check_runs = `#{GH_PATH} api repos/#{@repo_name}/commits/#{branch}/check-runs`
+
+    JSON.parse(check_runs)
+  rescue JSON::ParserError
+    { 'check_runs' => [] }
+  end
+
   def fetch_branches_not_open_prs
     owner, repo = @repo_name.split('/', 2)
 

--- a/gitbar_app/services/status_checks.rb
+++ b/gitbar_app/services/status_checks.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# StatusChecks
+# Unifies GitHub's two distinct commit-state systems into one vocabulary:
+#   1. Commit Statuses (legacy)  -> external CI POSTs on /statuses/{sha}
+#   2. Check Runs (Checks API)   -> GitHub Actions, /commits/{ref}/check-runs
+# Both are normalized to 'success' / 'failure' / 'pending' and can be
+# aggregated into a single overall state.
+module StatusChecks
+  module_function
+
+  # Check-run conclusions that must NOT be treated as a failure.
+  # neutral/skipped are non-blocking; success obviously passes.
+  NON_FAILING_CONCLUSIONS = %w[success neutral skipped].freeze
+  # Check-run conclusions that count as a failure.
+  FAILING_CONCLUSIONS = %w[failure timed_out cancelled action_required startup_failure stale].freeze
+
+  # Map a single check-run (status + conclusion) to success/failure/pending.
+  # queued / in_progress / waiting / requested means it has not finished yet.
+  def check_run_state(status:, conclusion:)
+    return 'pending' unless status.to_s.downcase == 'completed'
+
+    case conclusion.to_s.downcase
+    when *NON_FAILING_CONCLUSIONS then 'success'
+    when *FAILING_CONCLUSIONS then 'failure'
+    else 'pending'
+    end
+  end
+
+  # Map a legacy commit-status state to success/failure/pending.
+  # 'error' is treated as a failure; anything unfinished stays pending.
+  def commit_status_state(state)
+    case state.to_s.downcase
+    when 'success' then 'success'
+    when 'failure', 'error' then 'failure'
+    else 'pending'
+    end
+  end
+
+  # Aggregate normalized states into one overall state.
+  # failure if any failed; pending if any still running; success otherwise.
+  # Returns nil when there is nothing to aggregate.
+  def aggregate(states)
+    return nil if states.empty?
+    return 'failure' if states.include?('failure')
+    return 'pending' if states.include?('pending')
+
+    'success'
+  end
+
+  # Normalize REST check-run objects (commits/{ref}/check-runs) into the same
+  # shape as legacy commit "statuses[]" entries, so the view can render both
+  # the same way (description / state / target_url / created_at).
+  def normalize_check_runs(check_runs)
+    check_runs.map do |run|
+      {
+        'description' => run['name'],
+        'state' => check_run_state(status: run['status'], conclusion: run['conclusion']),
+        'target_url' => run['details_url'] || run['html_url'],
+        'created_at' => run['started_at'] || run['completed_at']
+      }
+    end
+  end
+end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PullRequest do
       'title' => 'test',
       'number' => 1,
       'url' => 'https://github.com/test/test',
-      'statusCheckRollup' => [{ 'targetUrl' => 'https://github.com/test/test', 'state' => 'success', 'context' => 'test' }],
+      'statusCheckRollup' => [{ '__typename' => 'StatusContext', 'targetUrl' => 'https://github.com/test/test', 'state' => 'SUCCESS', 'context' => 'test' }],
       'author' => { 'login' => 'test' },
       'updatedAt' => '2021-01-01',
       'mergeable' => 'MERGEABLE',
@@ -29,7 +29,7 @@ RSpec.describe PullRequest do
       expect(pull_request.number).to eq(pull_request_data['number'])
       expect(pull_request.url).to eq(pull_request_data['url'])
       expect(pull_request.status_check_rollup).to eq(pull_request_data['statusCheckRollup'][0]['targetUrl'])
-      expect(pull_request.status_check_rollup_state).to eq(pull_request_data['statusCheckRollup'][0]['state'])
+      expect(pull_request.status_check_rollup_state).to eq('SUCCESS')
       expect(pull_request.status_check_rollup_context).to eq(pull_request_data['statusCheckRollup'][0]['context'])
       expect(pull_request.author).to eq(pull_request_data['author']['login'])
       expect(pull_request.updated_at).to eq(pull_request_data['updatedAt'])
@@ -38,6 +38,54 @@ RSpec.describe PullRequest do
       expect(pull_request.review_requests).to be_empty
       expect(pull_request.is_mine?).to eq(pull_request_data['author']['login'] == USERNAME)
       expect(pull_request.can_be_merged?).to be_falsey
+    end
+  end
+
+  describe '#new with GitHub Actions check runs in the rollup' do
+    before do
+      allow(Review).to receive(:generate_reviews).and_return([])
+      allow(ReviewRequest).to receive(:generate_review_requests).and_return([])
+    end
+
+    def pr_with(rollup)
+      PullRequest.new(pr_data: pull_request_data.merge('statusCheckRollup' => rollup))
+    end
+
+    it 'aggregates CheckRun entries (which have status/conclusion, not state)' do
+      pr = pr_with([
+                     { '__typename' => 'CheckRun', 'name' => 'Test', 'status' => 'completed', 'conclusion' => 'success', 'detailsUrl' => 'https://gh/test' },
+                     { '__typename' => 'CheckRun', 'name' => 'Deploy', 'status' => 'completed', 'conclusion' => 'success', 'detailsUrl' => 'https://gh/deploy' }
+                   ])
+      expect(pr.status_check_rollup_state).to eq('SUCCESS')
+    end
+
+    it 'does not treat neutral/skipped conclusions as a failure' do
+      pr = pr_with([
+                     { '__typename' => 'CheckRun', 'name' => 'Lint', 'status' => 'completed', 'conclusion' => 'success', 'detailsUrl' => 'https://gh/lint' },
+                     { '__typename' => 'CheckRun', 'name' => 'Optional', 'status' => 'completed', 'conclusion' => 'skipped', 'detailsUrl' => 'https://gh/opt' },
+                     { '__typename' => 'CheckRun', 'name' => 'Note', 'status' => 'completed', 'conclusion' => 'neutral', 'detailsUrl' => 'https://gh/note' }
+                   ])
+      expect(pr.status_check_rollup_state).to eq('SUCCESS')
+    end
+
+    it 'reports pending while a run is in progress and points to it' do
+      pr = pr_with([
+                     { '__typename' => 'CheckRun', 'name' => 'Test', 'status' => 'completed', 'conclusion' => 'success', 'detailsUrl' => 'https://gh/test' },
+                     { '__typename' => 'CheckRun', 'name' => 'Deploy', 'status' => 'in_progress', 'conclusion' => nil, 'detailsUrl' => 'https://gh/deploy' }
+                   ])
+      expect(pr.status_check_rollup_state).to eq('PENDING')
+      expect(pr.status_check_rollup_context).to eq('Deploy')
+      expect(pr.status_check_rollup).to eq('https://gh/deploy')
+    end
+
+    it 'reports failure and points to the failing run when mixing systems' do
+      pr = pr_with([
+                     { '__typename' => 'StatusContext', 'context' => 'ci/external', 'state' => 'SUCCESS', 'targetUrl' => 'https://ext/ok' },
+                     { '__typename' => 'CheckRun', 'name' => 'Deploy', 'status' => 'completed', 'conclusion' => 'failure', 'detailsUrl' => 'https://gh/deploy' }
+                   ])
+      expect(pr.status_check_rollup_state).to eq('FAILURE')
+      expect(pr.status_check_rollup_context).to eq('Deploy')
+      expect(pr.status_check_rollup).to eq('https://gh/deploy')
     end
   end
 end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Repository do
       fake_service = instance_double(GhService)
       allow(fake_service).to receive(:fetch_pull_requests).and_return([])
       allow(fake_service).to receive(:fetch_status).and_return({ 'state' => 'success', 'statuses' => [] })
+      allow(fake_service).to receive(:fetch_check_runs).and_return({ 'check_runs' => [] })
       allow(GhService).to receive(:new).and_return(fake_service)
     end
 
@@ -22,6 +23,31 @@ RSpec.describe Repository do
       expect(repository.url).to eq("https://github.com/#{repository_data['name']}")
       expect(repository.status).to eq('success')
       expect(repository.status_details).to eq([])
+    end
+  end
+
+  describe '#current_status with GitHub Actions check runs' do
+    let(:check_runs) do
+      { 'check_runs' => [
+        { 'name' => 'Test', 'status' => 'completed', 'conclusion' => 'success', 'details_url' => 'https://gh/test', 'started_at' => '2026-06-26T00:00:00Z' },
+        { 'name' => 'Deploy', 'status' => 'completed', 'conclusion' => 'success', 'details_url' => 'https://gh/deploy', 'started_at' => '2026-06-26T00:01:00Z' }
+      ] }
+    end
+
+    before do
+      fake_service = instance_double(GhService)
+      allow(fake_service).to receive(:fetch_pull_requests).and_return([])
+      # Mirrors meridian: combined status is empty because Actions are invisible to it.
+      allow(fake_service).to receive(:fetch_status).and_return({ 'state' => 'pending', 'statuses' => [] })
+      allow(fake_service).to receive(:fetch_check_runs).and_return(check_runs)
+      allow(GhService).to receive(:new).and_return(fake_service)
+    end
+
+    it 'derives status from check runs instead of the empty combined status' do
+      repository = Repository.new(repository_data: repository_data)
+      expect(repository.status).to eq('success')
+      expect(repository.status_details.map { |d| d['description'] }).to eq(%w[Test Deploy])
+      expect(repository.status_details.first['state']).to eq('success')
     end
   end
 end


### PR DESCRIPTION
- Introduced a new StatusChecks service to unify commit statuses and check runs.
- Updated PullRequest and Repository models to aggregate and display status from both legacy commit statuses and GitHub Actions check runs.
- Enhanced GhService to fetch check runs separately.
- Updated specs to cover new functionality and ensure correct status aggregation.